### PR TITLE
Fix NumPy runtime error

### DIFF
--- a/contoso_manufacturing/developer/webapp-decode/requirements.txt
+++ b/contoso_manufacturing/developer/webapp-decode/requirements.txt
@@ -4,3 +4,4 @@ opencv-contrib-python==4.9.0.80
 ovmsclient==2023.1
 tabulate==0.9.0
 scipy==1.13.0
+numpy==1.26.4


### PR DESCRIPTION
Add NumPy version 1.26.4 to requirements to fix Dockerfile runtime error: numpy.core.multiarray failed to import